### PR TITLE
update 1.9.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.8.1" %}
+{% set version = "1.9.2" %}
 
 package:
   name: wordcloud
@@ -6,11 +6,12 @@ package:
 
 source:
   url: https://pypi.io/packages/source/w/wordcloud/wordcloud-{{ version }}.tar.gz
-  sha256: e6ef771aac17c1cf8558c8d5ef025796184066d7b78f8118aefe011fb0d22952
+  sha256: 71062ba6bfeaf1a7f8b6f18f6a8a7a810ef10973ebd9aa10c04d9fff690363d3
 
 build:
-  number: 2
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  skip: True  # [py<37]
   entry_points:
     - wordcloud_cli = wordcloud.__main__:main
 
@@ -20,6 +21,8 @@ requirements:
   host:
     - python
     - pip
+    - wheel
+    - setuptools
   run:
     - python
     - pillow
@@ -29,7 +32,10 @@ requirements:
 test:
   imports:
     - wordcloud
+  requires:
+    - pip
   commands:
+    - pip check
     - wordcloud_cli -h
 
 about:
@@ -37,6 +43,11 @@ about:
   license: MIT
   license_file: LICENSE
   summary: A little word cloud generator in Python
+  description: |
+    A little word cloud generator in Python.
+  dev_url: https://github.com/amueller/word_cloud
+  doc_url: http://amueller.github.io/word_cloud/
+
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,11 +42,12 @@ about:
   home: https://github.com/amueller/word_cloud
   license: MIT
   license_file: LICENSE
+  license_family: MIT
   summary: A little word cloud generator in Python
   description: |
     A little word cloud generator in Python.
   dev_url: https://github.com/amueller/word_cloud
-  doc_url: http://amueller.github.io/word_cloud/
+  doc_url: https://amueller.github.io/word_cloud/
 
 
 extra:


### PR DESCRIPTION
## ☆ Wordcloud 1.9.2 Update ☆
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-2282)
[Upstream](https://github.com/amueller/word_cloud/tree/1.9.2)
[Dependencies ](https://github.com/amueller/word_cloud/blob/1.9.2/setup.py)
# Changes
- Updated version number and `sha256`
- Updated pinnings on dependencies
- Added test for `pip` and `pip check` 
- Additional information in about section added